### PR TITLE
docs(website): add community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ The same content also lives in [`docs/`](docs/) for in-repo browsing.
 - **Slack:** Join the [CNCF Slack](https://slack.cncf.io/) workspace and find us in `#airunway`
 - **Issues:** Report bugs or request features in [GitHub Issues](https://github.com/ai-runway/airunway/issues)
 - **Roadmap:** Follow planned work on the [AI Runway project board](https://github.com/orgs/ai-runway/projects/2)
-- **Contributing:** Read the [contributing guide](CONTRIBUTING.md) to get started
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ The same content also lives in [`docs/`](docs/) for in-repo browsing.
 | Gateway Integration | [docs/gateway.md](docs/gateway.md) |
 | Headlamp Plugin | [docs/headlamp-plugin.md](docs/headlamp-plugin.md) |
 
+## Community
+
+- **Slack:** Join the [CNCF Slack](https://slack.cncf.io/) workspace and find us in `#airunway`
+- **Issues:** Report bugs or request features in [GitHub Issues](https://github.com/ai-runway/airunway/issues)
+- **Roadmap:** Follow planned work on the [AI Runway project board](https://github.com/orgs/ai-runway/projects/2)
+- **Contributing:** Read the [contributing guide](CONTRIBUTING.md) to get started
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup. We also accept [AI-assisted prompt requests](CONTRIBUTING.md#ai-assisted-contributions--prompt-requests).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -120,16 +120,20 @@ const config = {
             title: 'Community',
             items: [
               {
-                label: 'GitHub',
-                href: 'https://github.com/ai-runway/airunway',
+                label: 'Slack (#airunway)',
+                href: 'https://slack.cncf.io/',
               },
               {
                 label: 'Issues',
                 href: 'https://github.com/ai-runway/airunway/issues',
               },
               {
-                label: 'Discussions',
-                href: 'https://github.com/ai-runway/airunway/discussions',
+                label: 'Contributing',
+                href: 'https://github.com/ai-runway/airunway/blob/main/CONTRIBUTING.md',
+              },
+              {
+                label: 'Roadmap',
+                href: 'https://github.com/orgs/ai-runway/projects/2',
               },
             ],
           },

--- a/website/src/components/CtaSection.js
+++ b/website/src/components/CtaSection.js
@@ -4,10 +4,11 @@ import {ctaLinks} from '../data/landingPageData';
 
 export default function CtaSection() {
   return (
-    <section className="landing-section cta-section">
+    <section id="community" className="landing-section cta-section">
       <h2 className="section-title">Join the community</h2>
       <p className="section-subtitle">
-        Issues, ideas, and pull requests are all welcome.
+        Chat with us in <strong>#airunway</strong> on CNCF Slack, report an
+        issue, or help improve the project.
       </p>
       <div className="cta-buttons">
         {ctaLinks.map((link) => (

--- a/website/src/data/landingPageData.js
+++ b/website/src/data/landingPageData.js
@@ -66,16 +66,20 @@ export const providers = [
 
 export const ctaLinks = [
   {
-    label: 'GitHub',
-    href: 'https://github.com/ai-runway/airunway',
+    label: 'Join CNCF Slack',
+    href: 'https://slack.cncf.io/',
   },
   {
     label: 'Issues',
     href: 'https://github.com/ai-runway/airunway/issues',
   },
   {
-    label: 'Releases',
-    href: 'https://github.com/ai-runway/airunway/releases',
+    label: 'Contributing',
+    href: 'https://github.com/ai-runway/airunway/blob/main/CONTRIBUTING.md',
+  },
+  {
+    label: 'Roadmap',
+    href: 'https://github.com/orgs/ai-runway/projects/2',
   },
 ];
 


### PR DESCRIPTION
## Summary

- add the CNCF Slack `#airunway` channel to the homepage and README
- surface Issues, Contributing, and Roadmap links alongside Slack
- replace the unavailable Discussions footer link with current community resources

## Testing

- `cd website && bun run build`
- reviewed the website community section at desktop and mobile sizes in light and dark themes
- verified the external community links respond successfully
- `git diff --check`
