### PR TITLE
fix: Dynamo status set to nil when no frondend exists

### DIFF
--- a/providers/dynamo/status.go
+++ b/providers/dynamo/status.go
@@ -180,6 +180,8 @@ func (t *StatusTranslator) extractEndpoint(upstream *unstructured.Unstructured, 
 	if serviceName, found, _ := unstructured.NestedString(status, "endpoint", "service"); found {
 		endpoint.Service = serviceName
 	} else {
+		// Dynamo does not report an endpoint, so only infer one when its rendered
+		// spec includes the standalone Frontend service.
 		if !hasFrontendService(upstream) {
 			return nil
 		}
@@ -197,6 +199,7 @@ func (t *StatusTranslator) extractEndpoint(upstream *unstructured.Unstructured, 
 	return endpoint
 }
 
+// hasFrontendService reads the spec to check if a Frontend service exists.
 func hasFrontendService(upstream *unstructured.Unstructured) bool {
 	services, found, _ := unstructured.NestedMap(upstream.Object, "spec", "services")
 	if !found {

--- a/providers/dynamo/status.go
+++ b/providers/dynamo/status.go
@@ -180,6 +180,9 @@ func (t *StatusTranslator) extractEndpoint(upstream *unstructured.Unstructured, 
 	if serviceName, found, _ := unstructured.NestedString(status, "endpoint", "service"); found {
 		endpoint.Service = serviceName
 	} else {
+		if !hasFrontendService(upstream) {
+			return nil
+		}
 		// Default to deployment name + "-frontend"
 		endpoint.Service = fmt.Sprintf("%s-frontend", upstream.GetName())
 	}
@@ -192,6 +195,16 @@ func (t *StatusTranslator) extractEndpoint(upstream *unstructured.Unstructured, 
 	}
 
 	return endpoint
+}
+
+func hasFrontendService(upstream *unstructured.Unstructured) bool {
+	services, found, _ := unstructured.NestedMap(upstream.Object, "spec", "services")
+	if !found {
+		return false
+	}
+
+	_, hasFrontend := services["Frontend"]
+	return hasFrontend
 }
 
 // IsReady checks if the DynamoGraphDeployment is ready

--- a/providers/dynamo/status_test.go
+++ b/providers/dynamo/status_test.go
@@ -8,6 +8,10 @@ import (
 )
 
 func newDGDWithStatus(status map[string]interface{}) *unstructured.Unstructured {
+	return newDGDWithSpecAndStatus(nil, status)
+}
+
+func newDGDWithSpecAndStatus(spec map[string]interface{}, status map[string]interface{}) *unstructured.Unstructured {
 	obj := map[string]interface{}{
 		"apiVersion": "nvidia.com/v1alpha1",
 		"kind":       "DynamoGraphDeployment",
@@ -15,6 +19,9 @@ func newDGDWithStatus(status map[string]interface{}) *unstructured.Unstructured 
 			"name":      "test-dgd",
 			"namespace": "default",
 		},
+	}
+	if spec != nil {
+		obj["spec"] = spec
 	}
 	if status != nil {
 		obj["status"] = status
@@ -226,9 +233,18 @@ func TestTranslateStatusWithEndpoint(t *testing.T) {
 	}
 }
 
-func TestTranslateStatusDefaultEndpoint(t *testing.T) {
+func TestTranslateStatusNilEndpointWithoutFrontend(t *testing.T) {
 	st := NewStatusTranslator()
-	dgd := newDGDWithStatus(map[string]interface{}{
+	dgd := newDGDWithSpecAndStatus(map[string]interface{}{
+		"services": map[string]interface{}{
+			"Epp": map[string]interface{}{
+				"componentType": "epp",
+			},
+			"VllmWorker": map[string]interface{}{
+				"componentType": "worker",
+			},
+		},
+	}, map[string]interface{}{
 		"state": "successful",
 	})
 
@@ -236,8 +252,35 @@ func TestTranslateStatusDefaultEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if result.Endpoint != nil {
+		t.Fatalf("expected nil endpoint without standalone Frontend service, got %#v", result.Endpoint)
+	}
+}
+
+func TestTranslateStatusWithInferredFrontendEndpoint(t *testing.T) {
+	st := NewStatusTranslator()
+	dgd := newDGDWithSpecAndStatus(map[string]interface{}{
+		"services": map[string]interface{}{
+			"Frontend": map[string]interface{}{
+				"componentType": "frontend",
+			},
+			"VllmWorker": map[string]interface{}{
+				"componentType": "worker",
+			},
+		},
+	}, map[string]interface{}{
+		"state": "successful",
+	})
+
+	result, err := st.TranslateStatus(dgd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Endpoint == nil {
+		t.Fatal("expected inferred endpoint when standalone Frontend service is configured")
+	}
 	if result.Endpoint.Service != "test-dgd-frontend" {
-		t.Errorf("expected default service 'test-dgd-frontend', got %s", result.Endpoint.Service)
+		t.Errorf("expected inferred service 'test-dgd-frontend', got %s", result.Endpoint.Service)
 	}
 	if result.Endpoint.Port != 8000 {
 		t.Errorf("expected default port 8000, got %d", result.Endpoint.Port)

--- a/providers/dynamo/status_test.go
+++ b/providers/dynamo/status_test.go
@@ -1,6 +1,7 @@
 package dynamo
 
 import (
+	"context"
 	"testing"
 
 	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
@@ -8,10 +9,6 @@ import (
 )
 
 func newDGDWithStatus(status map[string]interface{}) *unstructured.Unstructured {
-	return newDGDWithSpecAndStatus(nil, status)
-}
-
-func newDGDWithSpecAndStatus(spec map[string]interface{}, status map[string]interface{}) *unstructured.Unstructured {
 	obj := map[string]interface{}{
 		"apiVersion": "nvidia.com/v1alpha1",
 		"kind":       "DynamoGraphDeployment",
@@ -19,9 +16,6 @@ func newDGDWithSpecAndStatus(spec map[string]interface{}, status map[string]inte
 			"name":      "test-dgd",
 			"namespace": "default",
 		},
-	}
-	if spec != nil {
-		obj["spec"] = spec
 	}
 	if status != nil {
 		obj["status"] = status
@@ -235,18 +229,18 @@ func TestTranslateStatusWithEndpoint(t *testing.T) {
 
 func TestTranslateStatusNilEndpointWithoutFrontend(t *testing.T) {
 	st := NewStatusTranslator()
-	dgd := newDGDWithSpecAndStatus(map[string]interface{}{
-		"services": map[string]interface{}{
-			"Epp": map[string]interface{}{
-				"componentType": "epp",
-			},
-			"VllmWorker": map[string]interface{}{
-				"componentType": "worker",
-			},
-		},
-	}, map[string]interface{}{
+	resources, err := NewTransformer().Transform(context.Background(), newTestMD("test-dgd", "default"))
+	if err != nil {
+		t.Fatalf("unexpected transformer error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 transformed resource, got %d", len(resources))
+	}
+
+	dgd := resources[0]
+	dgd.Object["status"] = map[string]interface{}{
 		"state": "successful",
-	})
+	}
 
 	result, err := st.TranslateStatus(dgd)
 	if err != nil {
@@ -259,18 +253,22 @@ func TestTranslateStatusNilEndpointWithoutFrontend(t *testing.T) {
 
 func TestTranslateStatusWithInferredFrontendEndpoint(t *testing.T) {
 	st := NewStatusTranslator()
-	dgd := newDGDWithSpecAndStatus(map[string]interface{}{
-		"services": map[string]interface{}{
-			"Frontend": map[string]interface{}{
-				"componentType": "frontend",
-			},
-			"VllmWorker": map[string]interface{}{
-				"componentType": "worker",
-			},
-		},
-	}, map[string]interface{}{
+	md := newTestMD("test-dgd", "default")
+	// the Transformer creates Frontend whenever spec.gateway.enabled is explicitly false.
+	gatewayEnabled := false
+	md.Spec.Gateway = &airunwayv1alpha1.GatewaySpec{Enabled: &gatewayEnabled}
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("unexpected transformer error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 transformed resource, got %d", len(resources))
+	}
+
+	dgd := resources[0]
+	dgd.Object["status"] = map[string]interface{}{
 		"state": "successful",
-	})
+	}
 
 	result, err := st.TranslateStatus(dgd)
 	if err != nil {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Fixes #332. As I was unable to get a GPU, I was unable to verify the change on Kubernetes. Using the dynamo-mocker forces the frontend path and does not verify my change.

The current `extractEndpoint` returns `<upstream-name>-frontend` as `endpoint.Service` field when DynamoGraphDeployment status has no endpoint.service value.

This PR changes the behavior, so that `<upstream-name>-frontend` is only returned when a frontend is confirmed to exist (when upstream object has spec.services.Frontend value). In gateway-enabled paths, when spec.services.Frontend does not exist, `extractEndpoint` returns nil. According to GPT 5.6: 

> For the default Gateway/EPP Dynamo topology, result.Endpoint should be nil because there is no direct frontend Service to advertise. The user should instead use ModelDeployment.status.gateway.endpoint to send inference requests through the Gateway.

In places where `status.endpoint.Service` is now used, `status.gateway.endpoint` should be used depending on the conditions. Below is one of the places. I believe it's more correct to use `status.gateway.endpoint` when appropriate and leaving `endpoint` nil, instead of writing that value to `status.endpoint.Service`. 

<img width="936" height="216" alt="image" src="https://github.com/user-attachments/assets/cb961d2d-591a-4158-b2b6-bceb3b062a4f" />


## AI Prompt (Optional)

<!-- 
If this PR was generated with AI assistance (GitHub Copilot, Claude, Cursor, etc.), 
share the prompt that created these changes. This helps reviewers:
- Understand your intent better than code alone
- Validate the approach before reviewing implementation
- Run the prompt themselves to verify or iterate

If you want to submit a "prompt request" (prompt-only, no code), please open a
new issue using the "Prompt Request" issue template instead of a pull request.
-->

<details>
<summary>🤖 AI Prompt Used</summary>

```
<!-- Paste your prompt here, or write "N/A - Manual implementation" -->
```

**AI Tool:** <!-- e.g., GitHub Copilot, Claude, Cursor -->

</details>

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

Fixes #332 

## Changes Made

<!-- List the key changes made in this PR -->

See description.


## Testing

<!-- Describe how you tested these changes -->

- [x] Unit tests pass (`bun run test`)
- [ ] Manual testing performed
- [ ] Tested with a Kubernetes cluster

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's style guidelines
- [x] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
