### PR TITLE
feat: show full Hugging Face model IDs in tooltips

### DIFF
--- a/frontend/src/components/models/HfModelCard.test.tsx
+++ b/frontend/src/components/models/HfModelCard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { HfModelSearchResult } from '@airunway/shared';
+import { HfModelCard } from './HfModelCard';
+
+vi.mock('@/hooks/useGpuOperator', () => ({
+  useGpuThroughput: () => ({ data: undefined, isLoading: false }),
+}));
+
+const model: HfModelSearchResult = {
+  id: 'Qwen/Qwen3-Coder-30B-A3B-Instruct',
+  author: 'Qwen',
+  name: 'Qwen3-Coder-30B-A3B-Instruct',
+  downloads: 1234,
+  likes: 56,
+  pipelineTag: 'text-generation',
+  libraryName: 'transformers',
+  architectures: ['Qwen3MoeForCausalLM'],
+  gated: false,
+  parameterCount: 30_000_000_000,
+  estimatedGpuMemory: '72 GB',
+  estimatedGpuMemoryGb: 72,
+  supportedEngines: ['vllm'],
+  compatible: true,
+};
+
+function renderCard() {
+  return render(
+    <MemoryRouter>
+      <HfModelCard model={model} />
+    </MemoryRouter>
+  );
+}
+
+describe('HfModelCard', () => {
+  it('shows the full model identifier when the truncated name is hovered', async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.hover(screen.getByRole('heading', { name: model.name }));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(model.id);
+  });
+
+  it('makes the full model identifier available from the keyboard', async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const modelName = screen.getByRole('heading', { name: model.name });
+    await user.tab();
+
+    expect(modelName).toHaveFocus();
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(model.id);
+  });
+});

--- a/frontend/src/components/models/HfModelCard.tsx
+++ b/frontend/src/components/models/HfModelCard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { GpuFitIndicator } from './GpuFitIndicator';
 import { ThroughputEstimate } from './ThroughputEstimate';
 import type { HfModelSearchResult } from '@airunway/shared';
@@ -65,7 +66,21 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, 
       <div className="pb-2">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
-            <h3 className="text-lg font-semibold text-white leading-tight truncate group-hover:text-cyan-400 transition-colors duration-200">{model.name}</h3>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <h3
+                    tabIndex={0}
+                    className="text-lg font-semibold text-white leading-tight truncate rounded-sm cursor-help group-hover:text-cyan-400 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/50"
+                  >
+                    {model.name}
+                  </h3>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" align="start" className="max-w-xs break-all">
+                  <p className="font-mono">{model.id}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <p className="text-xs text-slate-500 truncate mt-0.5">
               {model.author}
             </p>


### PR DESCRIPTION
## Description

Adds an accessible tooltip to truncated model names in the Hugging Face catalog. Users can now inspect the complete model identifier before choosing a model to deploy, while the card layout remains compact.

<img width="1512" height="747" alt="Screenshot 2026-08-25 at 1 42 10 pm" src="https://github.com/user-attachments/assets/81f183a5-ea9e-4609-a824-aa5bc8c72c0f" />


## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```text
Implement Airunway GitHub issue #303. Confirm the current Hugging Face catalog behavior, reuse the existing frontend tooltip primitives and conventions, expose the full model identifier accessibly before deployment, add appropriate frontend tests, and make the smallest cohesive change.
```

**AI Tool:** OpenAI Codex

</details>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #303

## Changes Made

- Show the complete Hugging Face model identifier when a truncated model name is hovered.
- Make the tooltip trigger keyboard-focusable with a visible focus indicator.
- Reuse the existing Radix-based frontend tooltip components and preserve the current card truncation/layout.
- Add component tests covering both pointer hover and keyboard focus.

## Testing

- [x] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [ ] Tested with a Kubernetes cluster

Additional validation:

- `bun run test src/components/models/HfModelCard.test.tsx` — 2 tests passed
- Full frontend suite — 154 tests passed
- Frontend production build — passed
- Frontend lint — 0 errors; only existing unrelated warnings
- Manual browser verification against a temporary mock H100 cluster — passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

Add a screenshot showing the full `Qwen/Qwen3-Coder-30B-A3B-Instruct` identifier in the tooltip over its truncated catalog card name.

## Additional Notes

- The tooltip is available through both pointer hover and keyboard focus.
- No backend, API, or deployment behavior changed.