### PR TITLE
fix(gateway): self-heal missing gateway namespace on reconcile

### DIFF
--- a/controller/internal/controller/gateway_reconciler.go
+++ b/controller/internal/controller/gateway_reconciler.go
@@ -1007,18 +1007,9 @@ func (r *ModelDeploymentReconciler) discoverModelName(ctx context.Context, servi
 func (r *ModelDeploymentReconciler) ensureGatewayAllowsNamespace(ctx context.Context, gwConfig *gateway.GatewayConfig, namespace string) error {
 	changed, err := r.updateGatewayAllowedNamespaces(ctx, gwConfig, func(crossNs map[string]bool) (map[string]bool, bool) {
 		if crossNs[namespace] {
-			// Already allowed for this namespace — nothing to do.
-			//
-			// Self-heal is deliberately narrow: a Gateway stuck in the pre-#333
-			// broken state (a Selector present but missing its own namespace) is
-			// repaired only when the cross-namespace set actually changes — i.e.
-			// when a genuinely NEW namespace is added here, or when the last
-			// cross-namespace tenant is removed on the cleanup path (which reverts
-			// to `from: Same`). It does NOT heal on a same-namespace re-reconcile
-			// of an already-stuck Gateway: if `namespace` is the only tenant and
-			// it is already listed, this short-circuit returns without a patch and
-			// gateway-ns stays evicted. That single-tenant-after-upgrade case must
-			// be healed by adding another namespace or deleting the MD.
+			// The shared helper still checks the terminal Selector invariant, so
+			// this logical no-op can repair a pre-#333 Selector that is missing the
+			// Gateway's own namespace without causing repeat patch churn.
 			return crossNs, false
 		}
 		crossNs[namespace] = true
@@ -1043,8 +1034,9 @@ func (r *ModelDeploymentReconciler) ensureGatewayAllowsNamespace(ctx context.Con
 //
 // mutate receives the current CROSS-namespace set (the Gateway's own namespace
 // already stripped) and returns the desired cross-namespace set plus whether
-// anything changed. Returning changed=false skips the patch entirely, preserving
-// each caller's early-out semantics.
+// the cross-namespace intent changed. Even when it returns changed=false, the
+// helper repairs a Selector that has cross-namespace entries but omits the
+// Gateway's own namespace. Once repaired, the same logical no-op skips the patch.
 //
 // The terminal rule (issue #333): a listener at the default `from: Same`
 // implicitly allows the Gateway's own namespace, but allowedNamespacesFromGateway
@@ -1073,11 +1065,13 @@ func (r *ModelDeploymentReconciler) updateGatewayAllowedNamespaces(
 
 		// Current allowed set may already include gw.Namespace (post-fix); strip
 		// it so callers reason purely about cross-namespace intent.
-		crossCur := stripNamespace(allowedNamespacesFromGateway(&gw), gw.Namespace)
+		current := allowedNamespacesFromGateway(&gw)
+		crossCur := stripNamespace(current, gw.Namespace)
 
 		desired, didChange := mutate(crossCur)
-		changed = didChange
-		if !didChange {
+		needsGatewayNamespace := len(desired) > 0 && !current[gw.Namespace]
+		changed = didChange || needsGatewayNamespace
+		if !changed {
 			return nil // nothing to patch
 		}
 

--- a/controller/internal/controller/gateway_reconciler_test.go
+++ b/controller/internal/controller/gateway_reconciler_test.go
@@ -1271,6 +1271,128 @@ func TestGateway_EnsurePreservesGatewayNamespaceOnSameToSelector(t *testing.T) {
 	}
 }
 
+// TestGateway_EnsureHealsMissingGatewayNamespaceWithoutPatchChurn covers the
+// upgrade drift from before issue #333: the tenant namespace is already present,
+// but the Selector omitted the Gateway's own namespace. The next reconcile must
+// repair the Selector, and subsequent reconciles must be no-ops.
+func TestGateway_EnsureHealsMissingGatewayNamespaceWithoutPatchChurn(t *testing.T) {
+	multiListener := gwWithNamespaceSelector("my-gateway", "gateway-ns", "team-a", "team-b")
+	secondListener := multiListener.Spec.Listeners[0]
+	secondListener.Name = "https"
+	secondListener.Port = 443
+	secondListener.Protocol = gatewayv1.HTTPSProtocolType
+	multiListener.Spec.Listeners = append(multiListener.Spec.Listeners, secondListener)
+
+	legacyMatchLabels := gwWithNamespaceSelector("my-gateway", "gateway-ns", "team-b")
+	legacyMatchLabels.Spec.Listeners[0].AllowedRoutes.Namespaces.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"kubernetes.io/metadata.name": "team-b"},
+	}
+
+	tests := []struct {
+		name string
+		gw   *gatewayv1.Gateway
+		want []string
+	}{
+		{
+			name: "single tenant",
+			gw:   gwWithNamespaceSelector("my-gateway", "gateway-ns", "team-b"),
+			want: []string{"gateway-ns", "team-b"},
+		},
+		{
+			name: "multiple tenants and listeners",
+			gw:   multiListener,
+			want: []string{"gateway-ns", "team-a", "team-b"},
+		},
+		{
+			name: "legacy matchLabels selector",
+			gw:   legacyMatchLabels,
+			want: []string{"gateway-ns", "team-b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			md := newModelDeployment("test-model", "team-b")
+			detector := fakeDetector(true, "my-gateway", "gateway-ns")
+			detector.PatchGateway = true
+
+			base := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&airunwayv1alpha1.ModelDeployment{}).
+				WithObjects(md, tc.gw).
+				Build()
+
+			patchCalls := 0
+			c := interceptor.NewClient(base, interceptor.Funcs{
+				Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if _, ok := obj.(*gatewayv1.Gateway); ok {
+						patchCalls++
+					}
+					return cl.Patch(ctx, obj, patch, opts...)
+				},
+			})
+
+			r := &ModelDeploymentReconciler{
+				Client:           c,
+				Scheme:           scheme,
+				GatewayDetector:  detector,
+				ProviderResolver: gateway.NewInferenceProviderConfigResolver(c),
+			}
+			ctx := context.Background()
+			gwConfig := &gateway.GatewayConfig{GatewayName: "my-gateway", GatewayNamespace: "gateway-ns"}
+
+			if err := r.ensureGatewayAllowsNamespace(ctx, gwConfig, "team-b"); err != nil {
+				t.Fatalf("first ensureGatewayAllowsNamespace failed: %v", err)
+			}
+			if patchCalls != 1 {
+				t.Fatalf("expected one self-heal patch, got %d", patchCalls)
+			}
+
+			var healed gatewayv1.Gateway
+			if err := r.Get(ctx, types.NamespacedName{Name: "my-gateway", Namespace: "gateway-ns"}, &healed); err != nil {
+				t.Fatalf("failed to get healed Gateway: %v", err)
+			}
+			for i, listener := range healed.Spec.Listeners {
+				if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil || listener.AllowedRoutes.Namespaces.Selector == nil {
+					t.Fatalf("listener[%d]: expected namespace Selector after self-heal", i)
+				}
+				namespaces := listener.AllowedRoutes.Namespaces
+				if namespaces.From == nil || *namespaces.From != gatewayv1.NamespacesFromSelector {
+					t.Fatalf("listener[%d]: expected from=Selector after self-heal, got %v", i, namespaces.From)
+				}
+				selector := namespaces.Selector
+				if len(selector.MatchLabels) != 0 {
+					t.Fatalf("listener[%d]: expected legacy matchLabels to be removed, got %v", i, selector.MatchLabels)
+				}
+				if len(selector.MatchExpressions) != 1 {
+					t.Fatalf("listener[%d]: expected one matchExpression, got %v", i, selector.MatchExpressions)
+				}
+				expression := selector.MatchExpressions[0]
+				if expression.Key != "kubernetes.io/metadata.name" || expression.Operator != metav1.LabelSelectorOpIn {
+					t.Fatalf("listener[%d]: unexpected namespace matchExpression: %v", i, expression)
+				}
+				values := expression.Values
+				if len(values) != len(tc.want) {
+					t.Fatalf("listener[%d]: expected healed selector values %v, got %v", i, tc.want, values)
+				}
+				for j := range tc.want {
+					if values[j] != tc.want[j] {
+						t.Fatalf("listener[%d]: expected healed selector values %v, got %v", i, tc.want, values)
+					}
+				}
+			}
+
+			if err := r.ensureGatewayAllowsNamespace(ctx, gwConfig, "team-b"); err != nil {
+				t.Fatalf("second ensureGatewayAllowsNamespace failed: %v", err)
+			}
+			if patchCalls != 1 {
+				t.Fatalf("expected repeat reconcile to avoid another patch, got %d total patches", patchCalls)
+			}
+		})
+	}
+}
+
 // TestGateway_EnsureRetriesOnConflictAndPreservesUnion proves the read-modify-write
 // is race-safe: when a concurrent writer adds a namespace and bumps the
 // resourceVersion between our Get and Patch, the optimistic-lock Patch conflicts,


### PR DESCRIPTION
### Summary

- Repair an existing Gateway `allowedRoutes` Selector when its cross-namespace tenant set is already correct but it omits the Gateway's own namespace.
- Route the drift repair through the existing optimistic-lock and retry path, while keeping subsequent reconciles patch-free once the Selector is healthy.
- Expand regression coverage across single and multiple tenants, multiple listeners, legacy `matchLabels` selectors, conflict retries, cleanup back to `from: Same`, and repeat-reconcile idempotency.

### Validation

- `go test ./internal/controller -run '^TestGateway_(EnsureHealsMissingGatewayNamespaceWithoutPatchChurn|EnsurePreservesGatewayNamespaceOnSameToSelector|EnsureRetriesOnConflictAndPreservesUnion|EnsureRetriesOnRealOptimisticLockConflict|CleanupRevertsAllowedRoutes|CleanupKeepsAllowedRoutesWhenOtherMDExists|CleanupRemovesOneNamespaceFromMultiple|EnsureAddsNamespaceToExistingSelector|EnsureMigratesLegacyMatchLabels)$' -count=1` — passed.
- `go build ./...` — passed.
- `make VERIFIED_VERSIONS=1 test` — passed controller generation, formatting, vet, Kubernetes 1.35 envtest, and all non-e2e controller packages.
- `./bin/golangci-lint run --new-from-rev=HEAD` — passed with `0 issues`.
- `bun run test` — version verification and all 152 frontend tests passed; 872 of 874 backend tests passed. The two unrelated credential-storage tests could not write `~/.airunway/credentials.json` inside the sandbox. They were not rerun with broader filesystem access because they write and delete the real user's credential path.

### Risks and limitations

- No live-cluster e2e test was run; the controller behavior is covered by fake-client unit tests and the full envtest suite.
- No CRD, generated API, dependency, frontend, or backend source files changed.

### Related issue

Fixes #365