### PR TITLE
fix: address remaining valid findings from issue #68

### DIFF
--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -90,9 +90,12 @@ func ensureBootstrapCerts(dir string) error {
 	certPath := filepath.Join(dir, "tls.crt")
 	keyPath := filepath.Join(dir, "tls.key")
 
-	// Skip if certs already exist
+	// Skip only when the complete certificate pair already exists. A lone
+	// certificate cannot start the webhook server without its private key.
 	if _, err := os.Stat(certPath); err == nil {
-		return nil
+		if _, err := os.Stat(keyPath); err == nil {
+			return nil
+		}
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/controller/cmd/main_test.go
+++ b/controller/cmd/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureBootstrapCertsRegeneratesIncompletePair(t *testing.T) {
+	tests := []struct {
+		name        string
+		existing    string
+		placeholder string
+	}{
+		{name: "missing private key", existing: "tls.crt", placeholder: "stale certificate"},
+		{name: "missing certificate", existing: "tls.key", placeholder: "stale private key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tt.existing), []byte(tt.placeholder), 0o600); err != nil {
+				t.Fatalf("write incomplete bootstrap pair: %v", err)
+			}
+
+			if err := ensureBootstrapCerts(dir); err != nil {
+				t.Fatalf("ensureBootstrapCerts() error = %v", err)
+			}
+			if _, err := tls.LoadX509KeyPair(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")); err != nil {
+				t.Fatalf("generated files are not a matching TLS pair: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureBootstrapCertsPreservesCompletePair(t *testing.T) {
+	dir := t.TempDir()
+	if err := ensureBootstrapCerts(dir); err != nil {
+		t.Fatalf("initial ensureBootstrapCerts() error = %v", err)
+	}
+
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	certBefore, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read initial certificate: %v", err)
+	}
+	keyBefore, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read initial private key: %v", err)
+	}
+
+	if err := ensureBootstrapCerts(dir); err != nil {
+		t.Fatalf("second ensureBootstrapCerts() error = %v", err)
+	}
+	certAfter, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read preserved certificate: %v", err)
+	}
+	keyAfter, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read preserved private key: %v", err)
+	}
+
+	if !bytes.Equal(certBefore, certAfter) || !bytes.Equal(keyBefore, keyAfter) {
+		t.Fatal("complete bootstrap pair was unexpectedly regenerated")
+	}
+}

--- a/controller/internal/controller/modeldeployment_controller.go
+++ b/controller/internal/controller/modeldeployment_controller.go
@@ -371,9 +371,43 @@ func (r *ModelDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	// Kubernetes garbage collection will handle cleanup when the ModelDeployment is deleted.
 
+	// A successful reconciliation resolves core-controller validation and
+	// selection failures. Clear the matching stale core-owned message without
+	// disturbing progress or readiness messages written by provider controllers.
+	clearResolvedCoreStatusMessage(base, &md)
+
 	logger.Info("Reconciliation complete", "name", md.Name, "phase", md.Status.Phase, "provider", md.Status.Provider)
 
 	return ctrl.Result{}, r.Status().Patch(ctx, &md, client.MergeFrom(base))
+}
+
+// clearResolvedCoreStatusMessage clears a message written by this controller
+// only when its matching condition is successful at the end of reconciliation.
+// Provider controllers also own status.message, so an unconditional clear
+// would erase their progress and readiness details.
+func clearResolvedCoreStatusMessage(base, current *airunwayv1alpha1.ModelDeployment) {
+	if base.Status.Message == "" || current.Status.Message != base.Status.Message {
+		return
+	}
+
+	resolvedFailures := []struct {
+		conditionType string
+		messagePrefix string
+	}{
+		{airunwayv1alpha1.ConditionTypeValidated, "Validation failed: "},
+		{airunwayv1alpha1.ConditionTypeEngineSelected, "Engine selection failed: "},
+		{airunwayv1alpha1.ConditionTypeProviderSelected, "Provider selection failed: "},
+		{airunwayv1alpha1.ConditionTypeProviderSelected, "No provider specified and provider-selector not enabled"},
+	}
+
+	for _, failure := range resolvedFailures {
+		resolved := meta.FindStatusCondition(current.Status.Conditions, failure.conditionType)
+		if resolved != nil && resolved.Status == metav1.ConditionTrue &&
+			strings.HasPrefix(base.Status.Message, failure.messagePrefix) {
+			current.Status.Message = ""
+			return
+		}
+	}
 }
 
 // isNoMatchError checks if an error indicates that a CRD/resource type is not registered.

--- a/controller/internal/controller/modeldeployment_validation_test.go
+++ b/controller/internal/controller/modeldeployment_validation_test.go
@@ -194,3 +194,89 @@ func TestReconcileAllowsSameExplicitProvider(t *testing.T) {
 		t.Fatalf("unexpected ProviderChangeNotSupported for an unchanged provider")
 	}
 }
+
+func TestReconcileClearsResolvedCoreValidationMessage(t *testing.T) {
+	tests := []struct {
+		name              string
+		conditionStatus   metav1.ConditionStatus
+		conditionReason   string
+		conditionMessage  string
+		deploymentMessage string
+	}{
+		{
+			name:              "failure resolves during this reconciliation",
+			conditionStatus:   metav1.ConditionFalse,
+			conditionReason:   "ValidationFailed",
+			conditionMessage:  "model.id is required when source is huggingface",
+			deploymentMessage: "Validation failed: model.id is required when source is huggingface",
+		},
+		{
+			name:              "condition recovered before controller upgrade",
+			conditionStatus:   metav1.ConditionTrue,
+			conditionReason:   "ValidationPassed",
+			conditionMessage:  "Schema validation passed",
+			deploymentMessage: "Validation failed: stale error from an earlier reconciliation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			md := newProviderSwitchMD("recovered-validation", "dynamo", "dynamo")
+			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
+			md.Status.Message = tt.deploymentMessage
+			md.Status.Conditions = []metav1.Condition{{
+				Type:               airunwayv1alpha1.ConditionTypeValidated,
+				Status:             tt.conditionStatus,
+				Reason:             tt.conditionReason,
+				Message:            tt.conditionMessage,
+				LastTransitionTime: metav1.Now(),
+			}}
+
+			r := newTestReconciler(scheme, nil, md)
+			r.EnableProviderSelector = false
+
+			if _, err := r.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: md.Name, Namespace: md.Namespace},
+			}); err != nil {
+				t.Fatalf("reconcile failed: %v", err)
+			}
+
+			var got airunwayv1alpha1.ModelDeployment
+			if err := r.Get(context.Background(), types.NamespacedName{Name: md.Name, Namespace: md.Namespace}, &got); err != nil {
+				t.Fatalf("failed to get reconciled ModelDeployment: %v", err)
+			}
+			if got.Status.Message != "" {
+				t.Fatalf("expected resolved core validation message to be cleared, got %q", got.Status.Message)
+			}
+			validated := meta.FindStatusCondition(got.Status.Conditions, airunwayv1alpha1.ConditionTypeValidated)
+			if validated == nil || validated.Status != metav1.ConditionTrue {
+				t.Fatalf("expected Validated=True after recovery, got %#v", validated)
+			}
+		})
+	}
+}
+
+func TestReconcilePreservesProviderStatusMessage(t *testing.T) {
+	scheme := newTestScheme()
+	md := newProviderSwitchMD("provider-progress", "dynamo", "dynamo")
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseDeploying
+	md.Status.Message = "DynamoGraphDeployment created, waiting for pods to be ready"
+
+	r := newTestReconciler(scheme, nil, md)
+	r.EnableProviderSelector = false
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: md.Name, Namespace: md.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	var got airunwayv1alpha1.ModelDeployment
+	if err := r.Get(context.Background(), types.NamespacedName{Name: md.Name, Namespace: md.Namespace}, &got); err != nil {
+		t.Fatalf("failed to get reconciled ModelDeployment: %v", err)
+	}
+	if got.Status.Message != md.Status.Message {
+		t.Fatalf("expected provider-owned status message to be preserved, got %q", got.Status.Message)
+	}
+}

--- a/frontend/src/hooks/useToast.test.tsx
+++ b/frontend/src/hooks/useToast.test.tsx
@@ -1,0 +1,53 @@
+import type { DependencyList, EffectCallback } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const effectLifecycle = vi.hoisted(() => ({ runs: 0, cleanups: 0 }))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>()
+  return {
+    ...actual,
+    useEffect(effect: EffectCallback, deps?: DependencyList) {
+      actual.useEffect(() => {
+        effectLifecycle.runs += 1
+        const cleanup = effect()
+        return () => {
+          effectLifecycle.cleanups += 1
+          if (typeof cleanup === 'function') cleanup()
+        }
+      }, deps)
+    },
+  }
+})
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useToast } from './useToast'
+
+describe('useToast', () => {
+  beforeEach(() => {
+    effectLifecycle.runs = 0
+    effectLifecycle.cleanups = 0
+  })
+
+  it('keeps one listener subscription across toast state updates', async () => {
+    const { result, unmount } = renderHook(() => useToast())
+
+    expect(effectLifecycle.runs).toBe(1)
+
+    act(() => {
+      result.current.toast({ title: 'First toast' })
+    })
+    await waitFor(() => expect(result.current.toasts[0]?.title).toBe('First toast'))
+
+    act(() => {
+      result.current.toast({ title: 'Second toast' })
+    })
+    await waitFor(() => expect(result.current.toasts[0]?.title).toBe('Second toast'))
+
+    expect(effectLifecycle.runs).toBe(1)
+    expect(effectLifecycle.cleanups).toBe(0)
+
+    unmount()
+    expect(effectLifecycle.cleanups).toBe(1)
+  })
+})

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -175,7 +175,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Description

Addresses the three findings from #68 that still reproduce on current `main`. The other two are now outdated: provider immutability is intentional (#325), and the webhook already has comprehensive test coverage.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Re-audit issue #68 against current main, fix only the findings that still reproduce, and add focused regression tests without changing provider immutability policy.
```

**AI Tool:** Codex

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #68

Relates to #325

## Changes Made

- Clear resolved controller-owned stale status messages without overwriting provider-written status.
- Regenerate webhook bootstrap credentials when either `tls.crt` or `tls.key` is missing.
- Keep the `useToast` listener stable across state updates.
- Add focused regression tests for all three fixes.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [ ] Manual testing performed
- [ ] Tested with a Kubernetes cluster

Passed:

- `cd controller && GOCACHE=/private/tmp/airunway-issue68-gocache make test`
- `cd controller && GOCACHE=/private/tmp/airunway-issue68-gocache go build ./...`
- `bun run --filter '@airunway/frontend' test`
- `bun run build:frontend`
- `bun run lint`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

Not applicable; there is no visual UI change.

## Additional Notes

All changed suites pass. The full `bun run test` was blocked only for two AuthService tests because the workspace sandbox cannot write `~/.airunway/credentials.json`.

Provider switching remains intentionally rejected; this PR does not change that policy.
