### PR TITLE
fix(dynamo): forward engine extra args to workers

### DIFF
--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -868,6 +868,10 @@ func (t *Transformer) buildEngineArgs(md *airunwayv1alpha1.ModelDeployment) ([]s
 		}
 	}
 
+	// Preserve raw token order after deterministic structured args. Disaggregated
+	// workers append Dynamo-owned role and KV-transfer flags after this result.
+	args = append(args, md.Spec.Engine.ExtraArgs...)
+
 	return args, nil
 }
 

--- a/providers/dynamo/transformer_test.go
+++ b/providers/dynamo/transformer_test.go
@@ -173,6 +173,83 @@ func TestTransformDisaggregated(t *testing.T) {
 	}
 }
 
+func TestTransformVLLMWorkersPreserveExtraArgs(t *testing.T) {
+	tr := NewTransformer()
+	extraArgs := []string{
+		"--airunway-extra-args-marker",
+		"expected-extra-args-value",
+		"--inline=value",
+		"--disaggregation-mode",
+		"user-supplied",
+	}
+
+	aggregated := newTestMD("aggregated", "default")
+	aggregated.Spec.Engine.ExtraArgs = extraArgs
+	aggregatedResources, err := tr.Transform(context.Background(), aggregated)
+	if err != nil {
+		t.Fatalf("transform aggregated deployment: %v", err)
+	}
+
+	disaggregated := newTestMD("disaggregated", "default")
+	disaggregated.Spec.Engine.ExtraArgs = extraArgs
+	disaggregated.Spec.Serving = &airunwayv1alpha1.ServingSpec{
+		Mode: airunwayv1alpha1.ServingModeDisaggregated,
+	}
+	disaggregated.Spec.Scaling = &airunwayv1alpha1.ScalingSpec{
+		Prefill: &airunwayv1alpha1.ComponentScalingSpec{
+			Replicas: 1,
+			GPU:      &airunwayv1alpha1.GPUSpec{Count: 1},
+		},
+		Decode: &airunwayv1alpha1.ComponentScalingSpec{
+			Replicas: 1,
+			GPU:      &airunwayv1alpha1.GPUSpec{Count: 1},
+		},
+	}
+	disaggregatedResources, err := tr.Transform(context.Background(), disaggregated)
+	if err != nil {
+		t.Fatalf("transform disaggregated deployment: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		resource  *unstructured.Unstructured
+		worker    string
+		ownedArgs []string
+		modelID   string
+	}{
+		{
+			name:     "aggregated",
+			resource: aggregatedResources[0],
+			worker:   "VllmWorker",
+			modelID:  aggregated.Spec.Model.ID,
+		},
+		{
+			name:      "prefill",
+			resource:  disaggregatedResources[0],
+			worker:    "VllmPrefillWorker",
+			ownedArgs: []string{"--disaggregation-mode", SubComponentTypePrefill, "--kv-transfer-config", VLLMKVTransferConfig},
+			modelID:   disaggregated.Spec.Model.ID,
+		},
+		{
+			name:      "decode",
+			resource:  disaggregatedResources[0],
+			worker:    "VllmDecodeWorker",
+			ownedArgs: []string{"--disaggregation-mode", SubComponentTypeDecode, "--kv-transfer-config", VLLMKVTransferConfig},
+			modelID:   disaggregated.Spec.Model.ID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			container := mainContainer(t, dgdService(t, tc.resource, tc.worker))
+			got := toStringSlice(t, container["args"])
+			want := append([]string{"--model", tc.modelID}, extraArgs...)
+			want = append(want, tc.ownedArgs...)
+			if !sliceEqual(got, want) {
+				t.Fatalf("worker args = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestMapEngineType(t *testing.T) {
 	tr := NewTransformer()
 
@@ -761,6 +838,36 @@ func TestBuildEngineArgsWithCustomArgs(t *testing.T) {
 	}
 	if !sliceContainsStr(args, "--tensor-parallel-size") {
 		t.Errorf("expected --tensor-parallel-size in args: %v", args)
+	}
+}
+
+func TestBuildEngineArgsAppendsExtraArgsVerbatim(t *testing.T) {
+	tr := NewTransformer()
+	md := newTestMD("test", "default")
+	md.Spec.Engine.Args = map[string]string{
+		"zebra-param": "z",
+		"alpha-param": "a",
+	}
+	md.Spec.Engine.ExtraArgs = []string{
+		"--airunway-extra-args-marker",
+		"expected-extra-args-value",
+		"--inline=value",
+	}
+
+	args, err := tr.buildEngineArgs(md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"--model", md.Spec.Model.ID,
+		"--alpha-param", "a",
+		"--zebra-param", "z",
+		"--airunway-extra-args-marker",
+		"expected-extra-args-value",
+		"--inline=value",
+	}
+	if !sliceEqual(args, want) {
+		t.Fatalf("buildEngineArgs() = %v, want %v", args, want)
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Forward `spec.engine.extraArgs` to all Dynamo workers in input order.

## AI Prompt (Optional)

<!-- 
If this PR was generated with AI assistance (GitHub Copilot, Claude, Cursor, etc.), 
share the prompt that created these changes. This helps reviewers:
- Understand your intent better than code alone
- Validate the approach before reviewing implementation
- Run the prompt themselves to verify or iterate

If you want to submit a "prompt request" (prompt-only, no code), please open a
new issue using the "Prompt Request" issue template instead of a pull request.
-->

<details>
<summary>🤖 AI Prompt Used</summary>

```
<!-- Paste your prompt here, or write "N/A - Manual implementation" -->
```

**AI Tool:** <!-- e.g., GitHub Copilot, Claude, Cursor -->

</details>

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->
Fixes #397 

## Changes Made

<!-- List the key changes made in this PR -->

- 

## Testing

<!-- Describe how you tested these changes -->

- [x] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's style guidelines
- [x] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Screenshots

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
